### PR TITLE
Use npx expo and add expo-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,20 @@ A mobile-first ADHD planner app built with Expo, React Native, NativeWind, and F
    ```bash
    npm install
    ```
+2. Install Expo CLI as a dev dependency:
 
-2. Start the development server:
+   ```bash
+   npm install --save-dev expo-cli
+   ```
+
+3. Start the development server:
 
    ```bash
    npm start
    ```
+   This runs `npx expo start` using the local Expo CLI.
 
-3. Scan the QR code with the Expo Go app on your mobile device or use an emulator.
+4. Scan the QR code with the Expo Go app on your mobile device or use an emulator.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
-    "web": "expo start --web"
+    "start": "npx expo start",
+    "android": "npx expo start --android",
+    "ios": "npx expo start --ios",
+    "web": "npx expo start --web"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.18",
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/react": "~18.2.45",
+    "expo-cli": "^7.2.1",
     "puppeteer": "^24.8.2",
     "sharp": "^0.34.1",
     "typescript": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "npx expo start",
     "android": "npx expo start --android",
     "ios": "npx expo start --ios",
-    "web": "npx expo start --web"
+    "web": "npx expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.18",
@@ -35,7 +36,9 @@
     "expo-cli": "^7.2.1",
     "puppeteer": "^24.8.2",
     "sharp": "^0.34.1",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "jest": "^29.7.0",
+    "react-test-renderer": "18.2.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- use `npx expo` for all npm scripts
- add `expo-cli` dev dependency
- document expo-cli setup in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683a6797f0148332a87160a0166fa970