### PR TITLE
Add Jest setup and sample tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ A mobile-first ADHD planner app built with Expo, React Native, NativeWind, and F
 
 3. Scan the QR code with the Expo Go app on your mobile device or use an emulator.
 
+4. Run the test suite:
+
+   ```bash
+   npm test
+   ```
+
 ## Project Structure
 
 ```
@@ -68,8 +74,3 @@ focuspatch/
 - Integrations with calendar apps
 - Advanced task categorization
 
-## Get started
-
-1. Install dependencies
-
-   ```

--- a/__tests__/Home.test.js
+++ b/__tests__/Home.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Home from '../app/index';
+
+describe('HomeScreen', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(<Home />).toJSON();
+    expect(tree).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.18",
@@ -34,7 +35,9 @@
     "@types/react": "~18.2.45",
     "puppeteer": "^24.8.2",
     "sharp": "^0.34.1",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "jest": "^29.7.0",
+    "react-test-renderer": "18.2.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add Jest and react-test-renderer as dev dependencies
- add a test script to package.json
- create a sample test for the Home screen
- document how to run tests in README
- clean up trailing broken section of README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a679295a88332ad8c1bd33eb92f04