### PR TITLE
Fix package.json scripts after merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "npx expo start",
     "android": "npx expo start --android",
     "ios": "npx expo start --ios",
-    "web": "npx expo start --web"
+    "web": "npx expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^6.1.18",
@@ -35,7 +36,9 @@
     "expo-cli": "^7.2.1",
     "puppeteer": "^24.8.2",
     "sharp": "^0.34.1",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "jest": "^29.7.0",
+    "react-test-renderer": "18.2.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- resolve merge conflict in package.json
- keep `npx` usage for expo
- restore `test` script and Jest deps

## Testing
- `npm test --silent` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a69b5e6208332bbc7829c86a01c87